### PR TITLE
add http client for dynamoDbClient!

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,7 @@ dependencyResolutionManagement {
             aws("eventbridge")
             aws("s3")
             aws("appconfigdata")
+            aws("apache-client")
 
             val slf4jVersion = version("slf4j", "1.8.0-beta4")
 

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
                 implementation(libs.aws.lambda.core)
                 implementation(libs.aws.lambda.events)
                 implementation(libs.jackson)
+                implementation(libs.aws.apache.client)
 
                 api(libs.kotlin.coroutines.core)
                 api(libs.kotlin.serialization.json)

--- a/test/src/jvmMain/kotlin/com/steamstreet/aws/test/dynamo.kt
+++ b/test/src/jvmMain/kotlin/com/steamstreet/aws/test/dynamo.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.awscore.exception.AwsServiceException
+import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder
@@ -66,6 +67,7 @@ class DynamoRunner {
         DynamoDbClient.builder()
             .endpointOverride(URI.create("http://localhost:$port")) // The region is meaningless for local DynamoDb but required for client builder validation
             .region(Region.US_EAST_1)
+            .httpClient(ApacheHttpClient.create())
             .credentialsProvider(
                 StaticCredentialsProvider.create(
                     AwsBasicCredentials.create("dummy-key", "dummy-secret")


### PR DESCRIPTION
I get `SdkClientException` if I don't add http client. I'm able to provide http client on a regular datastore. For example:

```
var dynamoKtClientBuilder: DynamoDbClientBuilder by mutableLazy {
    DynamoDbClient.builder().httpClient(ApacheHttpClient.create())
}
val db: DynamoKtSession = DynamoKtSession(
     dynamoKt,
     dynamoKtClientBuilder.build(),
     dynamoKt.table,
     dynamoKt.pkName,
     dynamoKt.skName
)
```
But I cannot do the same for `AWSLocal` in my test.