### PR TITLE
Log4J api in lambda

### DIFF
--- a/lambda/lambda-logging/build.gradle.kts
+++ b/lambda/lambda-logging/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     api(project(":logging"))
     implementation(libs.slf4j.logback.classic)
     implementation(libs.aws.lambda.core)
+    runtimeOnly(libs.log4j.api)
 }
 
 publishing {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -67,6 +67,8 @@ dependencyResolutionManagement {
             library("logstash-logback-encoder", "net.logstash.logback:logstash-logback-encoder:6.6")
             library("aws-dynamodb-local", "com.amazonaws:DynamoDBLocal:1.12.0")
 
+            library("log4j-api", "org.apache.logging.log4j", "log4j-api").version("2.23.1")
+
             val coroutineVersion = version("coroutines", "1.7.3")
             library(
                 "kotlin-coroutines-core", "org.jetbrains.kotlinx",


### PR DESCRIPTION
Add the Log4J API jar to the lambda logging package so that we avoid warnings from Lambda.